### PR TITLE
Podcast Api

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
         - master
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cypress/screenshots
 cypress/videos
 coverage
 .prettierrc.json
+.env

--- a/cypress/specs/Podcast.spec.ts
+++ b/cypress/specs/Podcast.spec.ts
@@ -14,63 +14,63 @@ describe('Podcast', () => {
     cy.visit('/');
   });
 
-  // it('should navigate to podcast page', () => {
-  //   cy.get(selectors.links.podcasts).first().click();
-  //   cy.url().should('include', authRoutes.podcast);
-  // });
+  it('should navigate to podcast page', () => {
+    cy.get(selectors.links.podcasts).last().click();
+    cy.url().should('include', authRoutes.podcast);
+  });
 
-  // it('should display the podcast table', () => {
-  //   cy.get(selectors.components.table.table).should('exist');
-  // });
+  it('should display the podcast table', () => {
+    cy.get(selectors.components.table.table).should('exist');
+  });
 
-  // it('should display table play buttons', () => {
-  //   cy.get(selectors.features.podcast.table.playButton)
-  //     .should('have.length', 5)
-  //     .should('exist');
-  // });
+  it('should display table play buttons', () => {
+    cy.get(selectors.features.podcast.table.playButton)
+      .should('have.length', 5)
+      .should('exist');
+  });
 
-  // it('should play first track in table', () => {
-  //   cy.get(selectors.features.podcast.table.playButton).first().click();
-  // });
+  it('should play first track in table', () => {
+    cy.get(selectors.features.podcast.table.playButton).first().click();
+  });
 
-  // it('should pause first track in table', () => {
-  //   cy.get(selectors.features.podcast.table.pauseButton).click();
-  // });
+  it('should pause first track in table', () => {
+    cy.get(selectors.features.podcast.table.pauseButton).click();
+  });
 
-  // it('should go to cycle page and display proper data', () => {
-  //   checkBaseTableNavigation([5, 10, 15], headers, mockPodcastData);
-  // });
+  it('should go to cycle page and display proper data', () => {
+    checkBaseTableNavigation([5, 10, 15], headers, mockPodcastData);
+  });
 
-  // it('should see drawer, player and details with proper data', () => {
-  //   checkPodcastDrawer(mockPodcastData[0]);
-  // });
+  it('should see drawer, player and details with proper data', () => {
+    checkPodcastDrawer(mockPodcastData[0]);
+  });
 
-  // it('should cycle tracks and show proper data in drawer', () => {
-  //   Array.from('01234')
-  //     .map(track => {
-  //       checkPodcastDrawer(mockPodcastData[track]);
-  //       cy.get(selectors.features.podcast.player.next).click();
-  //       return track;
-  //     })
-  //     .reverse()
-  //     .forEach(track => {
-  //       cy.get(selectors.features.podcast.player.previous).click();
-  //       checkPodcastDrawer(mockPodcastData[track]);
-  //       return track;
-  //     });
-  //   checkPodcastDrawer(mockPodcastData[0]);
-  // });
+  it('should cycle tracks and show proper data in drawer', () => {
+    Array.from('01234')
+      .map(track => {
+        checkPodcastDrawer(mockPodcastData[track]);
+        cy.get(selectors.features.podcast.player.next).click();
+        return track;
+      })
+      .reverse()
+      .forEach(track => {
+        cy.get(selectors.features.podcast.player.previous).click();
+        checkPodcastDrawer(mockPodcastData[track]);
+        return track;
+      });
+    checkPodcastDrawer(mockPodcastData[0]);
+  });
 
-  // it('should close drawer', () => {
-  //   cy.get(selectors.features.podcast.drawerClose)
-  //     .click()
-  //     .should('not.be.visible');
-  // });
+  it('should close drawer', () => {
+    cy.get(selectors.features.podcast.drawerClose)
+      .click()
+      .should('not.be.visible');
+  });
 
-  // ['25', '10', '5'].forEach(page => {
-  //   it(`should properly populate ${page} rows of data`, () => {
-  //     changeBlocksTableSize(page);
-  //     checkBlocksTableContent(headers, mockPodcastData);
-  //   });
-  // });
+  ['25', '10', '5'].forEach(page => {
+    it(`should properly populate ${page} rows of data`, () => {
+      changeBlocksTableSize(page);
+      checkBlocksTableContent(headers, mockPodcastData);
+    });
+  });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,5 +5,5 @@ import React from 'react';
 test('App', () => {
   // render(<App />);
   // const linkElement = screen.getAllByText('Podcast');
-  // expect(linkElement[0]).toBeInTheDocument();
+  expect(React).toBeTruthy();
 });

--- a/src/mock/data/podcast.ts
+++ b/src/mock/data/podcast.ts
@@ -469,5 +469,5 @@ const docs = [
     duration: 5898,
     published: '2020-05-13T00:32:31.734Z',
   },
-];
+] as PodcastData[];
 export default docs;

--- a/src/mock/service.ts
+++ b/src/mock/service.ts
@@ -1,30 +1,49 @@
 import { random } from 'faker';
 import { BaseData } from '../common/base';
 import { AxiosResponse } from 'axios';
-import { ServiceWrite, makeBaseService } from '../services/service';
+import { makeBaseService } from '../services/service';
+import { QueryResponse, ServiceWrite } from '../services/service.types';
 
 export const mockAxiosResponse = <T>(object?: T): Promise<AxiosResponse<T>> =>
   (Promise.resolve(object) as unknown) as Promise<AxiosResponse<T>>;
 
-export const mockService = <T extends BaseData>(docs: T[]): ServiceWrite<T> => {
+export const mockQueryResponse = <T>(results: T[]): QueryResponse<T> => ({
+  totalRowCount: 10,
+  currentPage: 1,
+  totalPageCount: 1,
+  firstRowOnPage: 1,
+  lastRowOnPage: 1,
+  results,
+  skipRowCount: 0,
+  takePageSize: 1,
+  fuzzySearchString: '',
+  orderByColName: '',
+  orderByAscending: true,
+  includeDeleted: false,
+});
+
+export const mockService = <T extends BaseData, API>(
+  docs: T[],
+): ServiceWrite<T> => {
   const baseRoute = 'mock';
-  const { http } = makeBaseService<T>(baseRoute);
-  const service = {
+  const { http } = makeBaseService<T, API>(baseRoute);
+  const service: ServiceWrite<T> = {
     baseRoute,
     http,
-    getById: (id: number) => mockAxiosResponse(docs.find(doc => doc.id === id)),
-    getAll: () => mockAxiosResponse(docs),
+    getById: (id: number) =>
+      Promise.resolve(docs.find(doc => doc.id === id) as T),
+    query: () => Promise.resolve(docs),
     create: (payload: T) =>
-      mockAxiosResponse({ id: random.number(), ...payload } as T),
+      Promise.resolve({ id: random.number(), ...payload } as T),
     update: (payload: T) => {
       const doc = docs.find(doc => doc.id === payload.id);
-      return mockAxiosResponse({ ...doc, ...payload });
+      return Promise.resolve({ ...doc, ...payload });
     },
     delete: (id: number) => {
       const doc = docs.find(doc => doc.id === id);
       const index = docs.indexOf(doc as T);
       docs.splice(index, 1);
-      return mockAxiosResponse<void>();
+      return Promise.resolve();
     },
   };
   return service;

--- a/src/podcast/components/PodcastTable.test.tsx
+++ b/src/podcast/components/PodcastTable.test.tsx
@@ -5,7 +5,6 @@ import { cyTable } from '../../components/Table/util';
 import { TestingUtil, testUtil } from '../../util/testing-util';
 import { podcastService } from '../../services/podcast';
 import mockPodcastDocs from '../../mock/data/podcast';
-import { mockAxiosResponse } from '../../mock/service';
 import { get } from 'lodash';
 import { headers } from './util';
 const wrapper = (): TestingUtil => {

--- a/src/podcast/components/PodcastTable.test.tsx
+++ b/src/podcast/components/PodcastTable.test.tsx
@@ -14,9 +14,7 @@ const wrapper = (): TestingUtil => {
 
 describe('PodcastTable', () => {
   beforeEach(jest.restoreAllMocks);
-  jest
-    .spyOn(podcastService, 'getAll')
-    .mockResolvedValue(mockAxiosResponse(mockPodcastDocs));
+  jest.spyOn(podcastService, 'query').mockResolvedValue(mockPodcastDocs);
 
   it('should display all labels', async () => {
     const { getAllByDataCy } = wrapper();

--- a/src/podcast/store/actions.test.ts
+++ b/src/podcast/store/actions.test.ts
@@ -77,9 +77,7 @@ describe('Podcast Actions', () => {
   });
 
   it('should call setPodcasts on loadPodcasts', async () => {
-    jest
-      .spyOn(podcastService, 'getAll')
-      .mockResolvedValue(mockAxiosResponse(mockPodcastDocs));
+    jest.spyOn(podcastService, 'query').mockResolvedValue(mockPodcastDocs);
     await dispatch(loadPodcasts());
     const expected = [
       makeAction(PODCAST_ACTIONS.SET_PODCASTS, mockPodcastDocs),
@@ -88,9 +86,7 @@ describe('Podcast Actions', () => {
   });
 
   it('should call selectPodcast and setPodcastPlay on playPodcast', async () => {
-    jest
-      .spyOn(podcastService, 'getAll')
-      .mockResolvedValue(mockAxiosResponse(mockPodcastDocs));
+    jest.spyOn(podcastService, 'query').mockResolvedValue(mockPodcastDocs);
     await dispatch(playPodcast(mockPodcastDocs));
     const expected = [
       makeAction(PODCAST_ACTIONS.SELECT_PODCAST, mockPodcastDocs),

--- a/src/podcast/store/actions.test.ts
+++ b/src/podcast/store/actions.test.ts
@@ -1,9 +1,4 @@
-import {
-  initialPodcastState,
-  PodcastActions,
-  PodcastState,
-  PODCAST_ACTIONS,
-} from './types';
+import { initialPodcastState, PodcastState, PODCAST_ACTIONS } from './types';
 import {
   loadPodcasts,
   playPodcast,
@@ -17,11 +12,11 @@ import {
 import mockPodcastDocs from '../../mock/data/podcast';
 import { makeAction, mockStore, strictEquals } from '../../util/testing-util';
 import { podcastService } from '../../services/podcast';
-import { mockAxiosResponse } from '../../mock/service';
+import { Actions } from '../../store/types';
 
-const received: PodcastActions[] = [];
+const received: Actions[] = [];
 
-const grabActions = (action: PodcastActions) => {
+const grabActions = (action: Actions) => {
   received.push(action);
 };
 

--- a/src/podcast/store/actions.ts
+++ b/src/podcast/store/actions.ts
@@ -58,7 +58,7 @@ export const loadPodcasts = (): AppThunkAsync => async (
   dispatch,
 ): Promise<undefined> => {
   try {
-    const podcasts = await podcastService.getAll();
+    const podcasts = await podcastService.query({ search: '' });
     dispatch(setPodcasts(podcasts));
     return;
   } catch (err) {

--- a/src/services/podcast.ts
+++ b/src/services/podcast.ts
@@ -1,8 +1,49 @@
-// import { makeService } from './service';
+import { makeService } from './service';
 import { mockService } from '../mock/service';
 import mockPodcastDocs from '../mock/data/podcast';
-// import { makeService } from './service';
+import { PodcastData } from '../common/podcast';
+import { pickBy } from 'lodash';
+import { HttpAdapters } from './service.types';
 
-// const baseRoute = '/podcast';
-// export const podcastService = makeService(baseRoute);
-export const podcastService = mockService(mockPodcastDocs);
+interface PodcastApiData {
+  description: string;
+  id?: number;
+  length: number;
+  number: number;
+  postedDate: string;
+  title: string;
+}
+
+const adapters: HttpAdapters<PodcastData, PodcastApiData> = {
+  request: (req: PodcastData): PodcastApiData => {
+    const data = ({
+      Id: req.id,
+      Number: req.number,
+      Title: req.title,
+      Description: req.description,
+      Length: req.duration,
+      PostedDate: req.published,
+    } as unknown) as PodcastApiData;
+    // FIXME: for some reason the api returns lowercase and takes in title case which breaks type
+    return (pickBy(data, d => d !== undefined) as unknown) as PodcastApiData;
+  },
+  response: (resp: PodcastApiData): PodcastData => {
+    const data: PodcastData = {
+      id: resp.id,
+      number: resp.number,
+      title: resp.title,
+      description: resp.description,
+      duration: resp.length,
+      published: resp.postedDate,
+    };
+    return (pickBy(data, d => d !== undefined) as unknown) as PodcastData;
+  },
+};
+
+const baseRoute = process.env.PODCAST_API;
+
+export const podcastService = makeService(
+  baseRoute,
+  adapters,
+  mockService(mockPodcastDocs),
+);

--- a/src/services/service.types.ts
+++ b/src/services/service.types.ts
@@ -1,0 +1,68 @@
+import { AxiosRequestConfig } from 'axios';
+import { BaseData } from '../common/base';
+
+export interface QueryParams {
+  includeDeleted: string;
+  skip: string;
+  take: string;
+  orderBy: string;
+  desc: string;
+  search: string;
+}
+
+export interface QueryResponse<T> {
+  totalRowCount: number;
+  currentPage: number;
+  totalPageCount: number;
+  firstRowOnPage: number;
+  lastRowOnPage: number;
+  results: T[];
+  skipRowCount: number;
+  takePageSize: number;
+  fuzzySearchString: string;
+  orderByColName: string;
+  orderByAscending: boolean;
+  includeDeleted: boolean;
+  additionalParameters?: Array<{
+    key: keyof QueryParams;
+    value: string;
+  }>;
+}
+
+export interface HttpAdapters<T extends BaseData, API> {
+  request: (req: T) => API;
+  response: (resp: API) => T;
+}
+
+export interface Http<TYPE extends BaseData> {
+  baseRoute: string;
+  get: (route: string, config?: AxiosRequestConfig) => Promise<TYPE>;
+  query: (route: string, config: AxiosRequestConfig) => Promise<TYPE[]>;
+  put: (
+    route: string,
+    payload: TYPE,
+    config?: AxiosRequestConfig,
+  ) => Promise<TYPE>;
+  post: (
+    route: string,
+    payload: TYPE,
+    config?: AxiosRequestConfig,
+  ) => Promise<TYPE>;
+  delete: (route: string, config?: AxiosRequestConfig) => Promise<void>;
+}
+
+export interface BaseService<TYPE extends BaseData> {
+  baseRoute: string;
+  http: Http<TYPE>;
+}
+
+export interface ServiceRead<T extends BaseData> extends BaseService<T> {
+  getById: (id: number) => Promise<T>;
+  query: (params: Partial<QueryParams>) => Promise<T[]>;
+}
+
+export interface ServiceWrite<T extends BaseData> extends ServiceRead<T> {
+  create: (payload: T) => Promise<T>;
+  update: (payload: T) => Promise<T>;
+  delete: (id: number) => Promise<void>;
+}


### PR DESCRIPTION
- [x] refactored service builder to handle new API style
- [x] added adapters to and from API
- [x] plumbed podcast service
- [x] added env var to Heroku config to supply service with Podcast API url (quick and dirty for now).
```
mattwoodruff@dev-box ~/repos/vindev/blocks (mw-podcast-service)$ heroku config
=== software-blocks Config Vars
PODCAST_API: https://jinnpodcast.azurewebsites.net/api/Podcast
```

Some issues I ran into:
- post doesn't respond with newly created record? Not a deal breaker but would be nice
- no redundancy checks are being made. I can post same doc with same track number, etc. A strategy around that may want to be considered? In mongo I set indexes on specific keys, not sure what is available.
- the API takes in keys that are title case and returns keys that are lowercase? could we make it consistent?
- query route was still having CORS issues(no access header on response, **will break once we merge if not fixed**)

![image](https://user-images.githubusercontent.com/8930703/101287447-ed9c8c00-37b5-11eb-8a70-c1fd21761572.png)
